### PR TITLE
Add KillMode=none in some services

### DIFF
--- a/systemd/user/kactivitymanagerd.service
+++ b/systemd/user/kactivitymanagerd.service
@@ -4,5 +4,6 @@ Before=plasmashell.service window-manager.service
 
 [Service]
 ExecStart=/usr/bin/kactivitymanagerd start-daemon
+KillMode=none
 BusName=org.kde.ActivityManager
 Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus" KDE_FULL_SESSION=1 KDE_SESSION_VERSION=5

--- a/systemd/user/kdeinit.service
+++ b/systemd/user/kdeinit.service
@@ -3,5 +3,6 @@ Description=KDE 'kdeinit' - TODO
 
 [Service]
 ExecStart=/usr/bin/kdeinit5 +kcminit_startup --no-fork
+KillMode=none
 BusName=org.kde.klauncher5
 Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus" KDE_FULL_SESSION=1 KDE_SESSION_VERSION=5

--- a/systemd/user/krunner.service
+++ b/systemd/user/krunner.service
@@ -3,6 +3,7 @@ Description=KDE Plasma Workspace Application Launcher
 
 [Service]
 ExecStart=/usr/bin/krunner
+KillMode=none
 BusName=org.kde.krunner
 Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus" KDE_FULL_SESSION=1 KDE_SESSION_VERSION=5
 

--- a/systemd/user/kwin.service
+++ b/systemd/user/kwin.service
@@ -5,6 +5,7 @@ Requires=kglobalaccel.service kded.service
 [Service]
 ExecStart=/usr/bin/kwin_x11 --replace
 BusName=org.kde.KWin
+KillMode=none
 Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus" KDE_FULL_SESSION=1 KDE_SESSION_VERSION=5
 
 [Install]

--- a/systemd/user/plasmashell.service
+++ b/systemd/user/plasmashell.service
@@ -6,6 +6,7 @@ Requires=ksmserver.service kuiserver.service kded.service kactivitymanagerd.serv
 ExecStart=/usr/bin/plasmashell --no-respawn
 ExecStop=/usr/bin/kquitapp5 plasmashell
 Restart=on-failure
+KillMode=none
 BusName=org.kde.plasmashell
 Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus" KDE_FULL_SESSION=1 KDE_SESSION_VERSION=5
 


### PR DESCRIPTION
This is workaround for DrKonqi, systemd assumes that service is dead when dbus address
is not visible on bus and tries to kill its child processes, but when something like
plasmashell crashes we still need its processes alive to get backtrace from DrKonqi.

This is workaround and should be replaced with proper solution in KCrash/processes.
Why this is workaround? systemd should be controlling processes but with this we trust
DrKonqi/kquitapp5 that they will do their cleanup

https://techbase.kde.org/User:Eliasp/Drafts/Plasma_Workspace_as_systemd_user-session#systemd.2FKCrash_race_conditions
