### PR TITLE
Revert "Improve handling of kglobalaccel's dependencies."

### DIFF
--- a/systemd/user/kactivitymanagerd.service
+++ b/systemd/user/kactivitymanagerd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=KDE Plasma Workspace Activity Manager
-Before=plasmashell.service window-manager.service kglobalaccel.service
+Before=plasmashell.service window-manager.service
 
 [Service]
 ExecStart=/usr/bin/kactivitymanagerd start-daemon

--- a/systemd/user/ksmserver.service
+++ b/systemd/user/ksmserver.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=KDE Session Management Server
-Requires=kglobalaccel.service
 
 [Service]
 ExecStart=/usr/bin/ksmserver

--- a/systemd/user/plasmashell.service
+++ b/systemd/user/plasmashell.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=KDE Plasma Workspace
-Requires=ksmserver.service kuiserver.service kded.service kactivitymanagerd.service kglobalaccel.service
+Requires=ksmserver.service kuiserver.service kded.service kactivitymanagerd.service
 
 [Service]
 ExecStart=/usr/bin/plasmashell --no-respawn


### PR DESCRIPTION
This reverts commit 6daec3f5fb48d9bc06a5378d41957127910e34a8.

Above commit added dependency to kglobalaccel to three components
however this is not nessesarry and brings some side effects.

- ksmserver is using kglobalaccel to register the lock/logout shortcuts
  and to get media/volume/brightness shortcuts on lockscreen but doesn't
  require it at startup.

- kactivitymanager doesn't require kglobalaccel at all, it doesn't
  register any shortcuts at all.

- Also this 3 components depending upon kglobalaccel means whenever
  kglobalaccel will be restarted this components will also be restarted
  which is un-necessary.. and can also kill session if timed correctly
  due to `sleep 5` hack. ;)